### PR TITLE
Update Django permissions and add changeset_type

### DIFF
--- a/django_project/apis/urls.py
+++ b/django_project/apis/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from .views import FeatureSpec, CreateFeature, UpdateFeature, FeatureSpecForChangeset
+from .views import FeatureSpec, CreateFeature, UpdateFeature, FeatureSpecForChangeset, FeatureHistory
 
 app_name = 'apis'
 
@@ -11,5 +11,6 @@ urlpatterns = (
     ),
     path('feature/<uuid:feature_uuid>/', FeatureSpec.as_view(), name='feature-spec'),
     path('create-feature/', CreateFeature.as_view(), name='create-feature'),
-    path('update-feature/<uuid:feature_uuid>/', UpdateFeature.as_view(), name='update-feature')
+    path('update-feature/<uuid:feature_uuid>/', UpdateFeature.as_view(), name='update-feature'),
+    path('feature-history/<uuid:feature_uuid>/', FeatureHistory.as_view(), name='feature-history')
 )

--- a/django_project/apis/urls.py
+++ b/django_project/apis/urls.py
@@ -1,10 +1,14 @@
 from django.urls import path
 
-from .views import FeatureSpec, CreateFeature, UpdateFeature
+from .views import FeatureSpec, CreateFeature, UpdateFeature, FeatureSpecForChangeset
 
 app_name = 'apis'
 
 urlpatterns = (
+    path(
+        'feature/<uuid:feature_uuid>/<int:changeset_id>/', FeatureSpecForChangeset.as_view(),
+        name='feature-spec-changeset'
+    ),
     path('feature/<uuid:feature_uuid>/', FeatureSpec.as_view(), name='feature-spec'),
     path('create-feature/', CreateFeature.as_view(), name='create-feature'),
     path('update-feature/<uuid:feature_uuid>/', UpdateFeature.as_view(), name='update-feature')

--- a/django_project/apis/views.py
+++ b/django_project/apis/views.py
@@ -22,6 +22,20 @@ class FeatureSpec(View):
             return HttpResponse(content=data, content_type='application/json')
 
 
+class FeatureSpecForChangeset(View):
+    def get(self, request, feature_uuid, changeset_id):
+
+        with connection.cursor() as cur:
+            cur.execute("""select * from core_utils.feature_spec(%s, %s, %s)""", [feature_uuid, True, changeset_id])
+
+            data = cur.fetchone()[0]
+
+        if data == '{}':
+            return HttpResponse(content=data, status=404, content_type='application/json')
+        else:
+            return HttpResponse(content=data, content_type='application/json')
+
+
 class CreateFeature(View):
     def get(self, request):
 

--- a/django_project/apis/views.py
+++ b/django_project/apis/views.py
@@ -1,8 +1,10 @@
+import datetime
 import json
 import uuid
 
 from django.db import connection, transaction
 from django.http import HttpResponse
+from django.utils import timezone
 from django.views import View
 
 from .utils import validate_payload
@@ -32,6 +34,25 @@ class FeatureSpecForChangeset(View):
 
         if data == '{}':
             return HttpResponse(content=data, status=404, content_type='application/json')
+        else:
+            return HttpResponse(content=data, content_type='application/json')
+
+
+class FeatureHistory(View):
+    def get(self, request, feature_uuid):
+
+        end_date = timezone.now()
+        start_date = end_date - datetime.timedelta(weeks=104)
+
+        with connection.cursor() as cur:
+            cur.execute(
+                'SELECT * FROM core_utils.get_feature_history_by_uuid(%s::uuid, %s, %s)',
+                (feature_uuid, start_date, end_date)
+            )
+            data = cur.fetchone()[0]
+
+        if data is None:
+            return HttpResponse(content='[]', status=404, content_type='application/json')
         else:
             return HttpResponse(content=data, content_type='application/json')
 

--- a/django_project/changesets/templates/changesets/changeset_explorer_page.html
+++ b/django_project/changesets/templates/changesets/changeset_explorer_page.html
@@ -17,6 +17,7 @@
                   <th class="col-md-2">Changeset</th>
                   <th class="col-md-6">Changed at</th>
                   <th class="col-md-4">Changed by</th>
+                  <th class="col-md-2">Type</th>
                 </tr>
                 <!-- http://www.hyperlinkcode.com/button-links.php -->
                 {% for changeset in changesets_list %}
@@ -24,6 +25,7 @@
                     <td>{{ changeset.changeset_id }}</td>
                     <td>{{ changeset.ts_created }}</td>
                     <td>{{ changeset.email }}</td>
+                    <td>{{ changeset.changeset_type }}</td>
                   </tr>
                 {% empty %}
                   <tr id="no_changesets">

--- a/django_project/changesets/views.py
+++ b/django_project/changesets/views.py
@@ -13,7 +13,7 @@ class ChangesetsExplorerView(AdminRequiredMixin, View):
             with connection.cursor() as cursor:
                 cursor.execute(
                     """
-                    SELECT features.changeset.id, to_char(ts_created, 'YYYY-MM-DD HH24:MI:SS TZ'), email
+                    SELECT features.changeset.id, to_char(ts_created, 'YYYY-MM-DD HH24:MI:SS TZ'), email, changeset_type
                     FROM features.changeset INNER JOIN public.webusers_webuser
                     ON features.changeset.webuser_id = public.webusers_webuser.id
                     ORDER BY ts_created DESC;
@@ -24,7 +24,7 @@ class ChangesetsExplorerView(AdminRequiredMixin, View):
 
         changesets_list = []
         for item in changesets:
-            changeset = {'changeset_id': item[0], 'ts_created': item[1], 'email': item[2]}
+            changeset = {'changeset_id': item[0], 'ts_created': item[1], 'email': item[2], 'changeset_type': item[3]}
             changesets_list.append(changeset)
 
         return render(request, 'changesets/changeset_explorer_page.html', {'changesets_list': changesets_list})

--- a/django_project/core/base_templates/navigation_bar.html
+++ b/django_project/core/base_templates/navigation_bar.html
@@ -54,6 +54,7 @@
                 <li><a href="/import_data/">Import Data</a></li>
                 <li><a href="/import_history/">Import History</a></li>
                 <li><a href="/changeset_explorer/">Changeset Explorer</a></li>
+                <li><a target="_blank" href="/admin-control/">Admin Page</a></li>
               </ul>
             </li>
           {% endif %}
@@ -66,9 +67,6 @@
             <ul class="dropdown-menu">
               <li><a href="/profile/">Update Profile</a></li>
               <li><a href="/change_password/">Change Password</a></li>
-              {% if user.is_staff %}
-                <li><a target="_blank" href="/admin-control/">Admin Page</a></li>
-              {% endif %}
             </ul>
           </li>
           <li>

--- a/django_project/core/base_templates/navigation_bar.html
+++ b/django_project/core/base_templates/navigation_bar.html
@@ -61,18 +61,14 @@
 
           <li id="profile_id" class="dropdown">
             <a href="#" class="nav-link-main" data-target="#" class="dropdown-toggle" data-toggle="dropdown">
-              Profile
+              {{ user.email }}
               <b class="caret"></b>
             </a>
             <ul class="dropdown-menu">
               <li><a href="/profile/">Update Profile</a></li>
               <li><a href="/change_password/">Change Password</a></li>
+              <li><a href="/logout/">Logout</a></li>
             </ul>
-          </li>
-          <li>
-            <a href="/logout/" class="nav-link-main">
-              Logout
-            </a>
           </li>
         {% endif %}
       </ul>

--- a/django_project/feature_diff/views.py
+++ b/django_project/feature_diff/views.py
@@ -29,7 +29,7 @@ class DifferenceViewer(LoginRequiredMixin, View):
             for ind, item in enumerate(available_changeset_ids):
                 available_changeset_ids[ind] = str(item[0])
 
-            changeset_id1 = self.kwargs.get('changeset_id1')
+            changeset_id1 = str(self.kwargs.get('changeset_id1'))
             if changeset_id1 not in available_changeset_ids:
                 changeset_id1 = available_changeset_ids[0]
 
@@ -39,7 +39,7 @@ class DifferenceViewer(LoginRequiredMixin, View):
             )
             changeset1_values = json.loads(cursor.fetchone()[0])[0]
 
-            changeset_id2 = self.kwargs.get('changeset_id2')
+            changeset_id2 = str(self.kwargs.get('changeset_id2'))
             if changeset_id2 not in available_changeset_ids:
                 try:
                     changeset_id2 = available_changeset_ids[1]

--- a/django_project/imports/views.py
+++ b/django_project/imports/views.py
@@ -97,8 +97,8 @@ class ImportDataTask(AdminRequiredMixin, View):
         with transaction.atomic():
             with connection.cursor() as cursor:
                 cursor.execute(
-                    'INSERT INTO features.changeset (webuser_id) VALUES (%s) RETURNING id', (
-                        request.user.pk,
+                    'INSERT INTO features.changeset (webuser_id, changeset_type) VALUES (%s, %s) RETURNING id', (
+                        request.user.pk, 'I'
                     )
                 )
                 changeset_id = cursor.fetchone()[0]
@@ -116,14 +116,13 @@ class ImportDataTask(AdminRequiredMixin, View):
                     with connection.cursor() as cursor:
                         for record in records_for_add:
                             cursor.execute(
-                                'SELECT core_utils.create_feature(%s, ST_SetSRID(ST_Point(%s, %s), 4326), %s, %s) ', (
-                                    request.user.pk,
+                                'SELECT core_utils.create_feature(%s, ST_SetSRID(ST_Point(%s, %s), 4326), %s) ', (
+                                    changeset_id,
 
                                     float(record['longitude']),
                                     float(record['latitude']),
 
-                                    json.dumps(record),
-                                    changeset_id
+                                    json.dumps(record)
                                 )
                             )
             except Exception:
@@ -136,16 +135,15 @@ class ImportDataTask(AdminRequiredMixin, View):
                         for record in records_for_update:
                             cursor.execute(
                                 """
-                                SELECT core_utils.update_feature(%s, %s, ST_SetSRID(ST_Point(%s, %s), 4326), %s, %s)
+                                SELECT core_utils.update_feature(%s, %s, ST_SetSRID(ST_Point(%s, %s), 4326), %s)
                                 """, (
+                                    changeset_id,
                                     record['feature_uuid'],
-                                    request.user.pk,
 
                                     float(record['longitude']),
                                     float(record['latitude']),
 
-                                    json.dumps(record),
-                                    changeset_id
+                                    json.dumps(record)
                                 )
                             )
             except Exception:

--- a/django_project/sql_scripts/10_features_schema.sql
+++ b/django_project/sql_scripts/10_features_schema.sql
@@ -7,5 +7,7 @@ CREATE TABLE features.changeset (
     id serial primary key,
 
     ts_created timestamp with time zone default now(),
-    webuser_id integer not null
+    webuser_id integer not null,
+    changeset_type text default 'U', -- 'S'ystem, 'U'ser, 'I'mport
+    metadata jsonb
 );

--- a/django_project/sql_scripts/25_core_utils_dashboard.sql
+++ b/django_project/sql_scripts/25_core_utils_dashboard.sql
@@ -494,7 +494,7 @@ create or replace function core_utils.filter_dashboard_table_data(
     i_order_text text
 )
     RETURNS SETOF text
-LANGUAGE plpgsql
+LANGUAGE plpgsql STABLE
 AS $$
 declare
     l_query text;

--- a/django_project/sql_scripts/30_load_data.sql
+++ b/django_project/sql_scripts/30_load_data.sql
@@ -12,11 +12,13 @@ INSERT INTO public.webusers_webuser (id, password, last_login, email, full_name,
 INSERT INTO features.changeset (
     id,
     webuser_id,
-    ts_created
+    ts_created,
+    changeset_type
 ) select
     1 as id,
     1 as webuser_id,
-    '2018-11-24T00:00:00' as ts_created;
+    '2018-11-24T00:00:00' as ts_created,
+    'I';
 
 -- attribute groups
 

--- a/django_project/sql_scripts/40_simulate_history_data.sql
+++ b/django_project/sql_scripts/40_simulate_history_data.sql
@@ -41,9 +41,9 @@ BEGIN
 
         -- insert new change set
         INSERT INTO
-                features.changeset (webuser_id, ts_created)
+                features.changeset (webuser_id, ts_created, changeset_type)
         VALUES
-                (1, v_ts_created);
+                (1, v_ts_created, 'S');
 
        -- raise notice '%' ,lastval();
         INSERT INTO

--- a/django_project/webusers/admin.py
+++ b/django_project/webusers/admin.py
@@ -98,12 +98,18 @@ class UserAdmin(BaseUserAdmin, LeafletGeoAdmin):
     default_lon = 4383204
     default_lat = 1431064
 
+    actions = None
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
 
 admin.site.register(WebUser, UserAdmin)
 
 
 class GrantsAdmin(admin.ModelAdmin):
     form = GrantForm
+    actions = None
 
 
 admin.site.register(Grant, GrantsAdmin)

--- a/os_build/mkosi.extra/srv/live/env_file
+++ b/os_build/mkosi.extra/srv/live/env_file
@@ -3,17 +3,18 @@
 SERVICE_PORT=8008
 DJANGO_SETTINGS_MODULE=core.settings.prod
 
-PGHOST=localhost
-PGPORT=15433
-PGUSER=dodobas
-PGDATABASE=waterboard_prod
-PGPASSWORD=qwertt
+PGHOST=<fill-this-in>
+PGPORT=<fill-this-in>
+PGUSER=<fill-this-in>
+PGDATABASE=<fill-this-in>
+PGPASSWORD=<fill-this-in>
 
-REDISHOST=localhost
-REDISPORT=16378
+REDISHOST=<fill-this-in>
+REDISPORT=<fill-this-in>
 
-DJANGO_SECRET="ije35jsp+giyf3qs^dr&a6nwv1%5h%bqva$4mf&=7r6tzv*1lj"
+# this needs to be filled in
+DJANGO_SECRET=
 
-SENTRY_DSN='https://7ca1d3963a464571860c611b44ed40d1:20988dbc9f1d4f1ba863f206b69e704d@sentry.io/290119'
+SENTRY_DSN=<fill-this-in>
 
-SERVICE_RELEASE=7.13
+SERVICE_RELEASE=<auto-fill>


### PR DESCRIPTION
Update Django admin permissions

- disable built-in Django admin actions
- disable delete on AttributeGroup and WebUser
- add support for AttributeOption update and delete


Add changeset_type to the Changeset relation

- define pg-function volatility
- show username on the navbar

Add API endpoints

- add feature-spec-for-changeset api endpoint
- add feature-history api endpoint